### PR TITLE
Articles management km

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -13,7 +13,8 @@ class Api::V1::ArticlesController < ApplicationController
   end
 
   def create
-    article = Article.create(article_params)
+    # article = Article.create(article_params)
+    article = current_user.articles.create(article_params)
     article.save!
     render json: serializer.new(article), status: 201
   rescue
@@ -23,9 +24,12 @@ class Api::V1::ArticlesController < ApplicationController
   end
 
   def update
-    article = Article.find(params[:id])
+    # article = Article.find(params[:id])
+    article = current_user.articles.find(params[:id])
     article.update!(article_params)
     render json: serializer.new(article), status: 200
+  rescue ActiveRecord::RecordNotFound
+    authorization_error
   rescue
     render json: {}, status: 422
   end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -12,6 +12,10 @@ class Api::V1::ArticlesController < ApplicationController
     render json: serializer.new(article)
   end
 
+  def create
+
+  end
+
   def serializer
     ArticleSerializer
   end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -13,11 +13,25 @@ class Api::V1::ArticlesController < ApplicationController
   end
 
   def create
-
+    article = Article.create(article_params)
+    if article.save
+      #success
+    else
+      render json: article, adapter: :json_api,
+        serializer: ErrorSerializer,
+        status: 422
+    end
   end
 
   def serializer
     ArticleSerializer
+  end
+
+  private
+
+  def article_params
+    # params[:article].permit(:title, :content)
+    ActionController::Parameters.new
   end
 
 end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -14,13 +14,12 @@ class Api::V1::ArticlesController < ApplicationController
 
   def create
     article = Article.create(article_params)
-    if article.save
-      render json: serializer.new(article), status: 201
-    else
-      render json: article, adapter: :json_api,
-        serializer: ErrorSerializer,
-        status: 422
-    end
+    article.save!
+    render json: serializer.new(article), status: 201
+  rescue
+    render json: article, adapter: :json_api,
+      serializer: ErrorSerializer,
+      status: 422
   end
 
   def serializer

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -15,7 +15,7 @@ class Api::V1::ArticlesController < ApplicationController
   def create
     article = Article.create(article_params)
     if article.save
-      #success
+      render json: serializer.new(article), status: 201
     else
       render json: article, adapter: :json_api,
         serializer: ErrorSerializer,
@@ -30,7 +30,8 @@ class Api::V1::ArticlesController < ApplicationController
   private
 
   def article_params
-    # params[:article].permit(:title, :content)
+    params.require(:data).require(:attributes)
+      .permit(:title, :content, :slug) ||
     ActionController::Parameters.new
   end
 

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -13,7 +13,6 @@ class Api::V1::ArticlesController < ApplicationController
   end
 
   def create
-    # article = Article.create(article_params)
     article = current_user.articles.create(article_params)
     article.save!
     render json: serializer.new(article), status: 201
@@ -24,7 +23,6 @@ class Api::V1::ArticlesController < ApplicationController
   end
 
   def update
-    # article = Article.find(params[:id])
     article = current_user.articles.find(params[:id])
     article.update!(article_params)
     render json: serializer.new(article), status: 200
@@ -32,6 +30,14 @@ class Api::V1::ArticlesController < ApplicationController
     authorization_error
   rescue
     render json: {}, status: 422
+  end
+
+  def destroy
+    article = current_user.articles.find(params[:id])
+    article.destroy
+    render status: 204
+  rescue
+    authorization_error
   end
 
   def serializer

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -22,6 +22,14 @@ class Api::V1::ArticlesController < ApplicationController
       status: 422
   end
 
+  def update
+    article = Article.find(params[:id])
+    article.update!(article_params)
+    render json: serializer.new(article), status: 200
+  rescue
+    render json: {}, status: 422
+  end
+
   def serializer
     ArticleSerializer
   end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -6,6 +6,8 @@ class Article < ApplicationRecord
 
   validates :slug, uniqueness: true
 
+  belongs_to :user
+
   scope :recent, -> { order(created_at: :desc) }
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,6 @@ class User < ApplicationRecord
             uniqueness: true
 
   has_one :access_token, dependent: :destroy
+
+  has_many :articles, dependent: :destroy
 end

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -1,0 +1,2 @@
+class ErrorSerializer < ActiveModel::Serializer::ErrorSerializer
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       post "/login", to: "access_tokens#create"
       delete "/logout", to: "access_tokens#destroy"
-      resources :articles, only: [:index, :show, :create]
+      resources :articles, only: [:index, :show, :create, :update]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       post "/login", to: "access_tokens#create"
       delete "/logout", to: "access_tokens#destroy"
-      resources :articles, only: [:index, :show, :create, :update]
+      resources :articles
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       post "/login", to: "access_tokens#create"
       delete "/logout", to: "access_tokens#destroy"
-      resources :articles, only: [:index, :show]
+      resources :articles, only: [:index, :show, :create]
     end
   end
 end

--- a/db/migrate/20210322002442_add_user_to_articles.rb
+++ b/db/migrate/20210322002442_add_user_to_articles.rb
@@ -1,0 +1,5 @@
+class AddUserToArticles < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :articles, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_18_143233) do
+ActiveRecord::Schema.define(version: 2021_03_22_002442) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,6 +29,8 @@ ActiveRecord::Schema.define(version: 2021_03_18_143233) do
     t.string "slug"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_articles_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -42,4 +44,5 @@ ActiveRecord::Schema.define(version: 2021_03_18_143233) do
   end
 
   add_foreign_key "access_tokens", "users"
+  add_foreign_key "articles", "users"
 end

--- a/spec/controllers/articles_spec.rb
+++ b/spec/controllers/articles_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::ArticlesController, type: :controller do
+  describe "#create" do
+    subject { post :create }
+    
+    context "when no code provided" do
+      it_behaves_like "unauthorized_requests"
+    end
+   
+    context "when invalid code provided" do
+      before { request.headers["authorization"] = "Invalid token" }
+      it_behaves_like "unauthorized_requests"
+    end
+
+    context "when invalid parameters provided" do
+
+    end
+  end
+
+
+end

--- a/spec/controllers/articles_spec.rb
+++ b/spec/controllers/articles_spec.rb
@@ -171,5 +171,57 @@ RSpec.describe Api::V1::ArticlesController, type: :controller do
       end
     end
   end
+  
+  describe "#destroy" do
+    let(:user) { create :user }
+    let(:article) { create :article, user: user }
+    let(:access_token) { user.create_access_token }
+
+    subject { delete :destroy, params: { id: article.id } }
+
+    context "when no code provided" do
+      it_behaves_like "unauthorized_requests"
+    end
+   
+    context "when invalid code provided" do
+      before { request.headers["authorization"] = "Invalid token" }
+      it_behaves_like "unauthorized_requests"
+    end
+
+    context "when trying to remove not owned article" do
+      let(:other_user) { create :user }
+      let(:other_article) { create :article, user: other_user }
+
+      subject { delete :destroy, params: { id: other_article.id } }
+      before { request.headers["authorization"] = "Bearer #{access_token.token}" }
+
+      it_behaves_like "unauthorized_requests"
+    end
+
+    context "when authorized" do
+      before { request.headers["authorization"] = "Bearer #{access_token.token}" }
+
+      context "when success request sent" do
+        before { request.headers["authorization"] = "Bearer #{access_token.token}" }
+
+        subject { delete :destroy, params: { id: article.id } }
+
+        it "should have 204 status code" do
+          subject
+          expect(response).to have_http_status(:no_content)
+        end
+
+        it "should have empty JSON body" do
+          subject
+          expect(response.body).to be_blank
+        end
+
+        it "should remove the article" do
+          article
+          expect { subject }.to change{ user.articles.count }.by(-1)
+        end
+      end
+    end
+  end
 
 end

--- a/spec/controllers/articles_spec.rb
+++ b/spec/controllers/articles_spec.rb
@@ -90,7 +90,9 @@ RSpec.describe Api::V1::ArticlesController, type: :controller do
   end
 
   describe "#update" do
-    let(:article) { create :article }
+    let(:user) { create :user }
+    let(:article) { create :article, user: user }
+    let(:access_token) { user.create_access_token }
 
     subject { patch :update, params: { id: article.id } }
 
@@ -103,8 +105,17 @@ RSpec.describe Api::V1::ArticlesController, type: :controller do
       it_behaves_like "unauthorized_requests"
     end
 
+    context "when trying to update not owned article" do
+      let(:other_user) { create :user }
+      let(:other_article) { create :article, user: other_user }
+
+      subject { patch :update, params: { id: other_article.id } }
+      before { request.headers["authorization"] = "Bearer #{access_token.token}" }
+
+      it_behaves_like "unauthorized_requests"
+    end
+
     context "when authorized" do
-      let(:access_token) { create :access_token }
       before { request.headers["authorization"] = "Bearer #{access_token.token}" }
 
       context "when invalid parameters provided" do
@@ -128,6 +139,8 @@ RSpec.describe Api::V1::ArticlesController, type: :controller do
       end
 
       context "when success request sent" do
+        before { request.headers["authorization"] = "Bearer #{access_token.token}" }
+
         let(:valid_attributes) do
           {
             data: {

--- a/spec/controllers/articles_spec.rb
+++ b/spec/controllers/articles_spec.rb
@@ -13,10 +13,48 @@ RSpec.describe Api::V1::ArticlesController, type: :controller do
       it_behaves_like "unauthorized_requests"
     end
 
-    context "when invalid parameters provided" do
+    context "when authorized" do
+      let(:access_token) { create :access_token }
+      before { request.headers["authorization"] = "Bearer #{access_token.token}" }
 
+      context "when invalid parameters provided" do
+        let(:invalid_attributes) do
+          {
+            data: {
+              attributes: {
+                title: "",
+                content: ""
+              }
+            }
+          }
+        end
+
+        subject { post :create, params: invalid_attributes }
+
+        it "should return 422 status code" do
+          subject
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        xit "should return proper error JSON" do
+          subject
+          expect(json_body[:errors]).to include(
+            {
+              "source" => { "pointer" => "/data/attributes/title" },
+              "detail" =>  "can't be blank"
+            },
+            {
+              "source" => { "pointer" => "/data/attributes/content" },
+              "detail" =>  "can't be blank"
+            },
+            {
+              "source" => { "pointer" => "/data/attributes/slug" },
+              "detail" =>  "can't be blank"
+            }
+          )
+        end
+      end
     end
   end
-
 
 end

--- a/spec/controllers/articles_spec.rb
+++ b/spec/controllers/articles_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe Api::V1::ArticlesController, type: :controller do
         end
 
         xit "should return proper error JSON" do
+          # need to refactor test due to reliance on 
+          # depricated 'active_model_sericalizers gem
           subject
           expect(json_body[:errors]).to include(
             {

--- a/spec/controllers/articles_spec.rb
+++ b/spec/controllers/articles_spec.rb
@@ -54,6 +54,36 @@ RSpec.describe Api::V1::ArticlesController, type: :controller do
           )
         end
       end
+
+      context "when success request sent" do
+        let(:valid_attributes) do
+          {
+            data: {
+              attributes: {
+                title: "Test Title",
+                content: "Test article content",
+                slug: "test-title-slug"
+              }
+            }
+          }
+        end
+
+        subject { post :create, params: valid_attributes }
+
+        it "should have 201 status code" do
+          subject
+          expect(response).to have_http_status(:created)
+        end
+
+        it "should have proper JSON body" do
+          subject
+          expect(json_body[:data][:attributes]).to include(valid_attributes[:data][:attributes])
+        end
+
+        it "should create the article" do
+          expect { subject }.to change{ Article.count }.by(1)
+        end
+      end
     end
   end
 

--- a/spec/factories/access_tokens.rb
+++ b/spec/factories/access_tokens.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :access_token do
-    token { "thisisatesttoken" }
-    user { nil }
+    # token is generated after initialzation
+    association :user
   end
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -3,5 +3,7 @@ FactoryBot.define do
     title { Faker::Book.title }
     content { Faker::Quote.yoda }
     slug { "slug-#{Faker::Beer.unique.yeast}" }
+
+    association :user
   end
 end

--- a/spec/routing/articles_spec.rb
+++ b/spec/routing/articles_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "/articles routes" do
   
   it "routes to articles#update" do
     expect(patch "/api/v1/articles/1").to route_to("api/v1/articles#update", id: "1")
+    expect(put "/api/v1/articles/1").to route_to("api/v1/articles#update", id: "1")
   end
 
 end

--- a/spec/routing/articles_spec.rb
+++ b/spec/routing/articles_spec.rb
@@ -20,5 +20,9 @@ RSpec.describe "/articles routes" do
     expect(patch "/api/v1/articles/1").to route_to("api/v1/articles#update", id: "1")
     expect(put "/api/v1/articles/1").to route_to("api/v1/articles#update", id: "1")
   end
+  
+  it "routes to articles#destroy" do
+    expect(delete "/api/v1/articles/1").to route_to("api/v1/articles#destroy", id: "1")
+  end
 
 end

--- a/spec/routing/articles_spec.rb
+++ b/spec/routing/articles_spec.rb
@@ -11,5 +11,9 @@ RSpec.describe "/articles routes" do
   it "routes to articles#show" do
     expect(get "/api/v1/articles/1").to route_to("api/v1/articles#show", id: "1")
   end
+  
+  it "routes to articles#create" do
+    expect(post "/api/v1/articles").to route_to("api/v1/articles#create")
+  end
 
 end

--- a/spec/routing/articles_spec.rb
+++ b/spec/routing/articles_spec.rb
@@ -15,5 +15,9 @@ RSpec.describe "/articles routes" do
   it "routes to articles#create" do
     expect(post "/api/v1/articles").to route_to("api/v1/articles#create")
   end
+  
+  it "routes to articles#update" do
+    expect(patch "/api/v1/articles/1").to route_to("api/v1/articles#update", id: "1")
+  end
 
 end


### PR DESCRIPTION
## Description
Adds full CRUD function for articles.  Also, restricts user access to allow modification to only their articles by adding a user association.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Notes
Skipped test is due to depricated `active_model_serializers` gem used in the lesson ([here](https://github.com/rails-api/active_model_serializers)).  May seek alternative testing if time allows in future.

Migration needed due to adding articles belonging to users relationship.

## RSpec Results
```
70 examples, 0 failures, 1 pending
```